### PR TITLE
Update to tabula version 1.0.1

### DIFF
--- a/src/Davincho/Tabula/Tabula.php
+++ b/src/Davincho/Tabula/Tabula.php
@@ -106,7 +106,7 @@ class Tabula
         $this->binDir = $binDir;
     }
 
-    public function parse($parameters = [], $file = null)
+    public function parse($parameters = [], $file = null, $utf8Encode = true)
     {
         $inputFile = $file !== null ? $file : $this->file;
         $parameters = is_array($parameters) ? $parameters : [$parameters];
@@ -124,6 +124,10 @@ class Tabula
 
         // Jar binary, with additional java option (see https://github.com/tabulapdf/tabula-java/issues/26)
         $arguments = ['-Xss2m', '-jar', $this->jarArchive, $inputFile];
+
+        if($utf8Encode) {
+            array_splice( $arguments, 2, 0, '-Dfile.encoding=utf-8' );
+        }
 
         $processBuilder = new ProcessBuilder();
         if($this->locale) {

--- a/src/Davincho/Tabula/Tabula.php
+++ b/src/Davincho/Tabula/Tabula.php
@@ -38,7 +38,7 @@ class Tabula
     /**
      * Path to jar file
      */
-    private $jarArchive = __DIR__ . '/../../../lib/tabula-extractor-0.7.4-SNAPSHOT-jar-with-dependencies.jar';
+    private $jarArchive = __DIR__ . '/../../../lib/tabula-1.0.1-jar-with-dependencies.jar';
 
     /**
      * Converter constructor.


### PR DESCRIPTION
I have updated the version of Tabula to 1.0.1 (last stable at the moment).

I have not deleted the old jar file since I did not know if it would cause any incompatibility problem for those who are already using this package. Please delete it if necessary.

Emiliano