### PR TITLE
Add getter/setter for jarArchive

### DIFF
--- a/src/Davincho/Tabula/Tabula.php
+++ b/src/Davincho/Tabula/Tabula.php
@@ -91,6 +91,22 @@ class Tabula
     }
 
     /**
+     * @return string
+     */
+    public function getJarArchive()
+    {
+        return $this->jarArchive;
+    }
+
+    /**
+     * @param string $jarArchive
+     */
+    public function setJarArchive($jarArchive)
+    {
+        $this->jarArchive = $jarArchive;
+    }
+
+    /**
      * @return mixed
      */
     public function getBinDir()
@@ -123,7 +139,7 @@ class Tabula
         }
 
         // Jar binary, with additional java option (see https://github.com/tabulapdf/tabula-java/issues/26)
-        $arguments = ['-Xss2m', '-jar', $this->jarArchive, $inputFile];
+        $arguments = ['-Xss2m', '-jar', $this->getJarArchive(), $inputFile];
 
         $processBuilder = new ProcessBuilder();
         if($this->locale) {


### PR DESCRIPTION
As this package is just a wrapper for tabula, it shouldnt dictate which version to use. Its nice to have a fallback to a version, but if a user needs to use a specific version it would be nice if thats possible. This commit makes that possible by adding getter/setter methods for `$jarArchive`.